### PR TITLE
Adding some default folders in .gitignore generated automatically by IDE's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_STORE
+.idea/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,40 @@
 .DS_STORE
+
+/dist/
+/bazel-out
+/integration/bazel/bazel-*
+e2e_test.*
+node_modules
+tools/gulp-tasks/cldr/cldr-data/
+
+# Include when developing application packages.
+pubspec.lock
+.c9
 .idea/
-.vscode/
+.devcontainer/*
+!.devcontainer/recommended-devcontainer.json
+!.devcontainer/recommended-Dockerfile
+.settings/
+.vscode/launch.json
+.vscode/settings.json
+*.swo
+modules/.settings
+modules/.vscode
+.vimrc
+.nvimrc
+
+# Don't check in secret files
+*secret.js
+
+# Ignore npm/yarn debug log
+npm-debug.log
+yarn-error.log
+
+# build-analytics
+.build-analytics
+
+# rollup-test output
+/modules/rollup-test/dist/
+
+# User specific bazel settings
+.bazelrc.user


### PR DESCRIPTION
Was hard to choose which files to ignore in a simple HTML project.

I thought of some default folders automatically generated by IDE's.

- [X] JetBrains
- [X] Visual Studio Code

I still think we can improve. 

Any suggestion?