### PR TITLE
fixed typo in git-playground/help-pages/pull-requests.html

### DIFF
--- a/help-pages/pull-requests.html
+++ b/help-pages/pull-requests.html
@@ -49,7 +49,7 @@
 			</ol>
 
 			<ul>
-				<li>If you can't see the PR proompt then use the gray button "New Pull Request" next to the branchs dropdown</li>
+				<li>If you can't see the PR prompt then use the gray button "New Pull Request" next to the branchs dropdown</li>
 			</ul>
 			<p>Below this p tag there is another p tag with the name and date of the last author. Change it for your own.</p>
 			<p>Sam, July 29 2019</p>


### PR DESCRIPTION
I have fixed a typo found in git-playground/help-pages/pull-requests.html. Let me know if that helped you to solve the Fix typos #6 issue.